### PR TITLE
Add extra logging for when commands fail

### DIFF
--- a/cmd/baton-1password/main.go
+++ b/cmd/baton-1password/main.go
@@ -45,7 +45,7 @@ func getConnector(ctx context.Context, cfg *config) (types.ConnectorServer, erro
 	// temp file for session token
 	tmpToken, _ := os.ReadFile(sessionTempFile)
 	if string(tmpToken) == "" {
-		token, err := onepassword.SignIn(cfg.Address)
+		token, err := onepassword.SignIn(ctx, cfg.Address)
 		if err != nil {
 			l.Error("failed to login: ", zap.Error(err))
 			return nil, err

--- a/pkg/1password/cli.go
+++ b/pkg/1password/cli.go
@@ -212,6 +212,7 @@ func (cli *Cli) executeCommand(ctx context.Context, args []string, res interface
 				"error executing command",
 				zap.Error(err),
 				zap.String("stderr", string(exitErr.Stderr)),
+				zap.String("stdout", string(output)),
 				zap.Int("exit_code", exitErr.ExitCode()),
 			)
 		}

--- a/pkg/1password/cli.go
+++ b/pkg/1password/cli.go
@@ -2,10 +2,15 @@ package onepassword
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
 )
 
 // 1Password CLI instance.
@@ -29,7 +34,9 @@ type AuthResponse struct {
 
 // Sign in to 1Password, returning the token.
 // In case account doesn't exist, it will prompt for account creation and will login the user.
-func SignIn(account string) (string, error) {
+func SignIn(ctx context.Context, account string) (string, error) {
+	l := ctxzap.Extract(ctx)
+
 	cmd := exec.Command("op", "signin", "--account", account, "--raw")
 	out := bytes.NewBuffer(nil)
 	cmd.Stdin = os.Stdin
@@ -38,6 +45,15 @@ func SignIn(account string) (string, error) {
 
 	err := cmd.Run()
 	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			l.Error(
+				"error executing command",
+				zap.Error(err),
+				zap.String("stderr", string(exitErr.Stderr)),
+				zap.Int("exit_code", exitErr.ExitCode()),
+			)
+		}
 		return "", fmt.Errorf("error starting command: %w", err)
 	}
 
@@ -45,11 +61,11 @@ func SignIn(account string) (string, error) {
 }
 
 // GetSignedInAccount gets information about the signed in account.
-func (cli *Cli) GetSignedInAccount() (AuthResponse, error) {
+func (cli *Cli) GetSignedInAccount(ctx context.Context) (AuthResponse, error) {
 	args := []string{"whoami"}
 
 	var res AuthResponse
-	err := cli.executeCommand(args, &res)
+	err := cli.executeCommand(ctx, args, &res)
 	if err != nil {
 		return AuthResponse{}, fmt.Errorf("error getting signed in account details: %w", err)
 	}
@@ -58,11 +74,11 @@ func (cli *Cli) GetSignedInAccount() (AuthResponse, error) {
 }
 
 // GetAccount gets information about the account.
-func (cli *Cli) GetAccount() (Account, error) {
+func (cli *Cli) GetAccount(ctx context.Context) (Account, error) {
 	args := []string{"account", "get"}
 
 	var res Account
-	err := cli.executeCommand(args, &res)
+	err := cli.executeCommand(ctx, args, &res)
 	if err != nil {
 		return Account{}, fmt.Errorf("error getting account: %w", err)
 	}
@@ -71,11 +87,11 @@ func (cli *Cli) GetAccount() (Account, error) {
 }
 
 // ListUsers lists all users in the account.
-func (cli *Cli) ListUsers() ([]User, error) {
+func (cli *Cli) ListUsers(ctx context.Context) ([]User, error) {
 	args := []string{"user", "list"}
 
 	var res []User
-	err := cli.executeCommand(args, &res)
+	err := cli.executeCommand(ctx, args, &res)
 	if err != nil {
 		return nil, fmt.Errorf("error listing users: %w", err)
 	}
@@ -84,11 +100,11 @@ func (cli *Cli) ListUsers() ([]User, error) {
 }
 
 // ListGroups lists all groups in the account.
-func (cli *Cli) ListGroups() ([]Group, error) {
+func (cli *Cli) ListGroups(ctx context.Context) ([]Group, error) {
 	args := []string{"group", "list"}
 
 	var res []Group
-	err := cli.executeCommand(args, &res)
+	err := cli.executeCommand(ctx, args, &res)
 	if err != nil {
 		return nil, fmt.Errorf("error listing groups: %w", err)
 	}
@@ -97,11 +113,11 @@ func (cli *Cli) ListGroups() ([]Group, error) {
 }
 
 // ListGroupMembers lists all members of a group.
-func (cli *Cli) ListGroupMembers(group string) ([]User, error) {
+func (cli *Cli) ListGroupMembers(ctx context.Context, group string) ([]User, error) {
 	args := []string{"group", "user", "list", group}
 
 	var res []User
-	err := cli.executeCommand(args, &res)
+	err := cli.executeCommand(ctx, args, &res)
 	if err != nil {
 		return nil, fmt.Errorf("error listing group members: %w", err)
 	}
@@ -110,11 +126,11 @@ func (cli *Cli) ListGroupMembers(group string) ([]User, error) {
 }
 
 // ListVaults lists all vaults in the account.
-func (cli *Cli) ListVaults() ([]Vault, error) {
+func (cli *Cli) ListVaults(ctx context.Context) ([]Vault, error) {
 	args := []string{"vault", "list"}
 
 	var res []Vault
-	err := cli.executeCommand(args, &res)
+	err := cli.executeCommand(ctx, args, &res)
 	if err != nil {
 		return nil, fmt.Errorf("error listing vaults: %w", err)
 	}
@@ -123,11 +139,11 @@ func (cli *Cli) ListVaults() ([]Vault, error) {
 }
 
 // ListVaultGroups lists all groups that have access to a vault.
-func (cli *Cli) ListVaultGroups(vaultId string) ([]Group, error) {
+func (cli *Cli) ListVaultGroups(ctx context.Context, vaultId string) ([]Group, error) {
 	args := []string{"vault", "group", "list", vaultId}
 
 	var res []Group
-	err := cli.executeCommand(args, &res)
+	err := cli.executeCommand(ctx, args, &res)
 	if err != nil {
 		return nil, fmt.Errorf("error listing vault groups: %w", err)
 	}
@@ -136,11 +152,11 @@ func (cli *Cli) ListVaultGroups(vaultId string) ([]Group, error) {
 }
 
 // ListVaultMembers lists all users that have access to a vault.
-func (cli *Cli) ListVaultMembers(vaultId string) ([]User, error) {
+func (cli *Cli) ListVaultMembers(ctx context.Context, vaultId string) ([]User, error) {
 	args := []string{"vault", "user", "list", vaultId}
 
 	var res []User
-	err := cli.executeCommand(args, &res)
+	err := cli.executeCommand(ctx, args, &res)
 	if err != nil {
 		return nil, fmt.Errorf("error listing vault members: %w", err)
 	}
@@ -149,10 +165,10 @@ func (cli *Cli) ListVaultMembers(vaultId string) ([]User, error) {
 }
 
 // AddUserToGroup adds user to group.
-func (cli *Cli) AddUserToGroup(group, role, user string) error {
+func (cli *Cli) AddUserToGroup(ctx context.Context, group, role, user string) error {
 	args := []string{"group", "user", "grant", "--group", group, "--role", role, "--user", user}
 
-	err := cli.executeCommand(args, nil)
+	err := cli.executeCommand(ctx, args, nil)
 	if err != nil {
 		return fmt.Errorf("error adding user as a member: %w", err)
 	}
@@ -160,7 +176,7 @@ func (cli *Cli) AddUserToGroup(group, role, user string) error {
 	// role can either member or manager but in order for user to be a manager the member role needs to be assigned first.
 	// so we execute the command once more in order for member to become a manager.
 	if role == "manager" {
-		err := cli.executeCommand(args, nil)
+		err := cli.executeCommand(ctx, args, nil)
 		if err != nil {
 			return fmt.Errorf("error adding user as a manager: %w", err)
 		}
@@ -170,10 +186,10 @@ func (cli *Cli) AddUserToGroup(group, role, user string) error {
 }
 
 // RemoveUserFromGroup removes user from group.
-func (cli *Cli) RemoveUserFromGroup(group, user string) error {
+func (cli *Cli) RemoveUserFromGroup(ctx context.Context, group, user string) error {
 	args := []string{"group", "user", "revoke", "--group", group, "--user", user}
 
-	err := cli.executeCommand(args, nil)
+	err := cli.executeCommand(ctx, args, nil)
 	if err != nil {
 		return fmt.Errorf("error removing user from group: %w", err)
 	}
@@ -181,13 +197,25 @@ func (cli *Cli) RemoveUserFromGroup(group, user string) error {
 	return nil
 }
 
-func (cli *Cli) executeCommand(args []string, res interface{}) error {
+func (cli *Cli) executeCommand(ctx context.Context, args []string, res interface{}) error {
+	l := ctxzap.Extract(ctx)
+
 	defaultArgs := []string{"--format=json", "--session", cli.token}
 	defaultArgs = append(args, defaultArgs...)
 
 	cmd := exec.Command("op", defaultArgs...) // #nosec
 	output, err := cmd.Output()
 	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			l.Error(
+				"error executing command",
+				zap.Error(err),
+				zap.String("stderr", string(exitErr.Stderr)),
+				zap.Int("exit_code", exitErr.ExitCode()),
+			)
+		}
+
 		return fmt.Errorf("error: %w", err)
 	}
 

--- a/pkg/connector/account.go
+++ b/pkg/connector/account.go
@@ -40,10 +40,10 @@ func accountResource(account onepassword.Account) (*v2.Resource, error) {
 	return ret, nil
 }
 
-func (a *accountResourceType) List(_ context.Context, _ *v2.ResourceId, _ *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (a *accountResourceType) List(ctx context.Context, _ *v2.ResourceId, _ *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
 	var rv []*v2.Resource
 
-	account, err := a.cli.GetAccount()
+	account, err := a.cli.GetAccount(ctx)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -68,9 +68,9 @@ func (a *accountResourceType) Entitlements(_ context.Context, resource *v2.Resou
 	return rv, "", nil, nil
 }
 
-func (a *accountResourceType) Grants(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+func (a *accountResourceType) Grants(ctx context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
 	var rv []*v2.Grant
-	users, err := a.cli.ListUsers()
+	users, err := a.cli.ListUsers(ctx)
 	if err != nil {
 		return nil, "", nil, err
 	}

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -54,7 +54,7 @@ func (op *OnePassword) Metadata(ctx context.Context) (*v2.ConnectorMetadata, err
 }
 
 func (op *OnePassword) Validate(ctx context.Context) (annotations.Annotations, error) {
-	_, err := op.cli.GetSignedInAccount()
+	_, err := op.cli.GetSignedInAccount(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("op-connector: failed to get signed in account: %w", err)
 	}

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -56,14 +56,14 @@ func groupResource(group onepassword.Group, parentResourceID *v2.ResourceId) (*v
 	return ret, nil
 }
 
-func (g *groupResourceType) List(_ context.Context, parentId *v2.ResourceId, _ *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (g *groupResourceType) List(ctx context.Context, parentId *v2.ResourceId, _ *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
 	if parentId == nil {
 		return nil, "", nil, nil
 	}
 
 	var rv []*v2.Resource
 
-	groups, err := g.cli.ListGroups()
+	groups, err := g.cli.ListGroups(ctx)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -93,10 +93,10 @@ func (g *groupResourceType) Entitlements(_ context.Context, resource *v2.Resourc
 	return rv, "", nil, nil
 }
 
-func (g *groupResourceType) Grants(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+func (g *groupResourceType) Grants(ctx context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
 	var rv []*v2.Grant
 
-	groupMembers, err := g.cli.ListGroupMembers(resource.Id.Resource)
+	groupMembers, err := g.cli.ListGroupMembers(ctx, resource.Id.Resource)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -132,7 +132,7 @@ func (o *groupResourceType) Grant(ctx context.Context, principal *v2.Resource, e
 		return nil, fmt.Errorf("baton-1password: only users can be granted group membership")
 	}
 
-	err := o.cli.AddUserToGroup(entitlement.Resource.Id.Resource, entitlement.Slug, principal.Id.Resource)
+	err := o.cli.AddUserToGroup(ctx, entitlement.Resource.Id.Resource, entitlement.Slug, principal.Id.Resource)
 
 	if err != nil {
 		return nil, fmt.Errorf("baton-1password: failed adding user to group")
@@ -156,7 +156,7 @@ func (o *groupResourceType) Revoke(ctx context.Context, grant *v2.Grant) (annota
 		return nil, errors.New("baton-1password: only users can have group membership revoked")
 	}
 
-	err := o.cli.RemoveUserFromGroup(entitlement.Resource.Id.Resource, principal.Id.Resource)
+	err := o.cli.RemoveUserFromGroup(ctx, entitlement.Resource.Id.Resource, principal.Id.Resource)
 
 	if err != nil {
 		return nil, errors.New("baton-1password: failed removing user from group")

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -70,14 +70,14 @@ func userResource(user onepassword.User, parentResourceID *v2.ResourceId) (*v2.R
 	return ret, nil
 }
 
-func (u *userResourceType) List(_ context.Context, parentId *v2.ResourceId, _ *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (u *userResourceType) List(ctx context.Context, parentId *v2.ResourceId, _ *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
 	if parentId == nil {
 		return nil, "", nil, nil
 	}
 
 	var rv []*v2.Resource
 
-	users, err := u.cli.ListUsers()
+	users, err := u.cli.ListUsers(ctx)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -98,7 +98,7 @@ func (u *userResourceType) Entitlements(_ context.Context, _ *v2.Resource, _ *pa
 	return nil, "", nil, nil
 }
 
-func (u *userResourceType) Grants(_ context.Context, _ *v2.Resource, _ *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+func (u *userResourceType) Grants(ctx context.Context, _ *v2.Resource, _ *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
 	return nil, "", nil, nil
 }
 

--- a/pkg/connector/vault.go
+++ b/pkg/connector/vault.go
@@ -61,14 +61,14 @@ func vaultResource(vault onepassword.Vault, parentResourceID *v2.ResourceId) (*v
 	return ret, nil
 }
 
-func (g *vaultResourceType) List(_ context.Context, parentId *v2.ResourceId, _ *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (g *vaultResourceType) List(ctx context.Context, parentId *v2.ResourceId, _ *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
 	if parentId == nil {
 		return nil, "", nil, nil
 	}
 
 	var rv []*v2.Resource
 
-	vaults, err := g.cli.ListVaults()
+	vaults, err := g.cli.ListVaults(ctx)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -85,10 +85,10 @@ func (g *vaultResourceType) List(_ context.Context, parentId *v2.ResourceId, _ *
 	return rv, "", nil, nil
 }
 
-func (g *vaultResourceType) Entitlements(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+func (g *vaultResourceType) Entitlements(ctx context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
 	var rv []*v2.Entitlement
 
-	account, err := g.cli.GetAccount()
+	account, err := g.cli.GetAccount(ctx)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -115,17 +115,17 @@ func (g *vaultResourceType) Entitlements(_ context.Context, resource *v2.Resourc
 	return rv, "", nil, nil
 }
 
-func (g *vaultResourceType) Grants(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+func (g *vaultResourceType) Grants(ctx context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
 	var rv []*v2.Grant
 	var userPermissionGrant *v2.Grant
 	var groupPermissionGrant *v2.Grant
 
-	account, err := g.cli.GetAccount()
+	account, err := g.cli.GetAccount(ctx)
 	if err != nil {
 		return nil, "", nil, err
 	}
 
-	vaultMembers, err := g.cli.ListVaultMembers(resource.Id.Resource)
+	vaultMembers, err := g.cli.ListVaultMembers(ctx, resource.Id.Resource)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -150,14 +150,14 @@ func (g *vaultResourceType) Grants(_ context.Context, resource *v2.Resource, _ *
 		}
 	}
 
-	vaultGroups, err := g.cli.ListVaultGroups(resource.Id.Resource)
+	vaultGroups, err := g.cli.ListVaultGroups(ctx, resource.Id.Resource)
 	if err != nil {
 		return nil, "", nil, err
 	}
 
 	for _, group := range vaultGroups {
 		groupCopy := group
-		groupMembers, err := g.cli.ListGroupMembers(groupCopy.ID)
+		groupMembers, err := g.cli.ListGroupMembers(ctx, groupCopy.ID)
 		if err != nil {
 			return nil, "", nil, err
 		}


### PR DESCRIPTION
When calling `op`, if it returns a non-zero exit code, we should now see the error logs. This should help with further debugging of issues.