### PR TITLE
If we fail to run an op command, include the command we ran in the log.

### DIFF
--- a/pkg/1password/cli.go
+++ b/pkg/1password/cli.go
@@ -214,6 +214,7 @@ func (cli *Cli) executeCommand(ctx context.Context, args []string, res interface
 				zap.String("stderr", string(exitErr.Stderr)),
 				zap.String("stdout", string(output)),
 				zap.Int("exit_code", exitErr.ExitCode()),
+				zap.Strings("command_args", cmd.Args),
 			)
 		}
 


### PR DESCRIPTION
This will add the following to error logs when executing a command:
`"cmd_args":["op","vault","group","list","<redacted group ID>","--format=json","--session",""]`