### PR TITLE
docs: apply C1 rebrand to connector.mdx

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,27 +1,27 @@
 ---
 title: "Set up 1Password connector"
-description: "ConductorOne provides identity governance and just-in-time provisioning for 1Password. Integrate your 1Password instance with ConductorOne to run user access reviews (UARs) and enable just-in-time access requests."
+description: "C1 provides identity governance and just-in-time provisioning for 1Password. Integrate your 1Password instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
 og:title: "Set up 1Password connector"
-og:description: "ConductorOne provides identity governance and just-in-time provisioning for 1Password. Integrate your 1Password instance with ConductorOne to run user access reviews (UARs) and enable just-in-time access requests."
+og:description: "C1 provides identity governance and just-in-time provisioning for 1Password. Integrate your 1Password instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
 sidebarTitle: "1Password"
 ---
 
 <Tip>
 **Why does this connector look different from most others?** 
 
-Unlike most of the software ConductorOne integrates with, 1Password doesn’t expose APIs that can be used to connect the two systems. Additionally, 1Password data can only be gathered from unlocked vaults, which means that a user must unlock the vault and manually kick off the data collection process; a periodic automated data pull won’t work.
+Unlike most of the software C1 integrates with, 1Password doesn’t expose APIs that can be used to connect the two systems. Additionally, 1Password data can only be gathered from unlocked vaults, which means that a user must unlock the vault and manually kick off the data collection process; a periodic automated data pull won’t work.
 
-To work around these issues, ConductorOne’s [1Password Baton connector](https://github.com/ConductorOne/baton-1password) uses the [1Password CLI](https://developer.1password.com/docs/cli/) to interact with your vaults. Once the CLI is set up, `baton-1password` uses it to interact with your 1Password vaults. The connector will capture user and entitlement data in a file that you upload to ConductorOne.
+To work around these issues, C1’s [1Password Baton connector](https://github.com/conductorone/baton-1password) uses the [1Password CLI](https://developer.1password.com/docs/cli/) to interact with your vaults. Once the CLI is set up, `baton-1password` uses it to interact with your 1Password vaults. The connector will capture user and entitlement data in a file that you upload to C1.
 </Tip>
 
 ## Capabilities
 
 | Resource | Sync | Provision |
 | :--- | :--- | :--- |
-| Accounts | <Icon icon="square-check" iconType="solid"  color="#65DE23"/> |  |
-| Groups | <Icon icon="square-check" iconType="solid"  color="#65DE23"/> | <Icon icon="square-check" iconType="solid"  color="#65DE23"/> |
-| Vaults | <Icon icon="square-check" iconType="solid"  color="#65DE23"/> | <Icon icon="square-check" iconType="solid"  color="#65DE23"/> |
-| Projects | <Icon icon="square-check" iconType="solid"  color="#65DE23"/> |  |
+| Accounts | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |  |
+| Groups | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
+| Vaults | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
+| Projects | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |  |
 
 Note that if you’re using a service account to run the connector, you can only provision access to vaults that were created by that service account.
 
@@ -30,14 +30,14 @@ Note that if you’re using a service account to run the connector, you can only
 <Warning>
 **To complete this task, you’ll need:**
 
-- The **Connector Administrator** or **Super Administrator** role in ConductorOne
+- The **Connector Administrator** or **Super Administrator** role in C1
 - [1Password 8](https://1password.com/downloads/mac/) on a Families, Teams, Business, or Enterprise plan
 - A 1Password vault
 </Warning>
 
 <Tabs>
 <Tab title="Cloud-hosted">
-**Follow these instructions to use a built-in, no-code connector hosted by ConductorOne.**
+**Follow these instructions to use a built-in, no-code connector hosted by C1.**
 
 *Cloud-hosted connector not currently available.*
 </Tab>
@@ -90,11 +90,11 @@ Note that if you’re using a service account to run the connector, you can only
     </Step>
 </Steps>
 
-### Step 3: Configure the 1Password connector in ConductorOne
+### Step 3: Configure the 1Password connector in C1
 
 <Steps>
     <Step>
-    In ConductorOne, navigate to **Integrations** > **Connectors** > **Add connector**.
+    In C1, navigate to **Integrations** > **Connectors** > **Add connector**.
     </Step>
     <Step>
     Search for **Baton** and click **Add**.
@@ -102,14 +102,14 @@ Note that if you’re using a service account to run the connector, you can only
     <Step>
     Choose how to set up the new 1Password connector:
 	
-    - Add the connector to a currently unmanaged app (select from the list of apps that were discovered in your identity, SSO, or federation provider that aren’t yet managed with ConductorOne)
+    - Add the connector to a currently unmanaged app (select from the list of apps that were discovered in your identity, SSO, or federation provider that aren’t yet managed with C1)
 	- Add the connector to a managed app (select from the list of existing managed apps)
 	- Create a new managed app
     </Step>
     <Step>
-    Set the owner for this connector. You can manage the connector yourself, or choose someone else from the list of ConductorOne users. Setting multiple owners is allowed.
+    Set the owner for this connector. You can manage the connector yourself, or choose someone else from the list of C1 users. Setting multiple owners is allowed.
 	
-    If you choose someone else, ConductorOne will notify the new connector owner by email that their help is needed to complete the setup process.
+    If you choose someone else, C1 will notify the new connector owner by email that their help is needed to complete the setup process.
     </Step>
     <Step>
     Click **Next**.
@@ -133,14 +133,14 @@ Note that if you’re using a service account to run the connector, you can only
     Run `baton-1password --help` to see the list of flags to be used when passing your credentials to the connector.
     </Step>
     <Step>
-    The connector syncs current data, uploads it to ConductorOne, and prints a `Task complete!` message when finished.
+    The connector syncs current data, uploads it to C1, and prints a `Task complete!` message when finished.
     </Step>
     <Step>
-    Check that the connector data uploaded correctly. In ConductorOne, click **Apps**. On the **Managed apps** tab, locate and click the name of the application you added the Baton connector to. The data should be found on the **Resources** and **Accounts** tabs, as appropriate.
+    Check that the connector data uploaded correctly. In C1, click **Apps**. On the **Managed apps** tab, locate and click the name of the application you added the Baton connector to. The data should be found on the **Resources** and **Accounts** tabs, as appropriate.
     </Step>
 </Steps>
 
-**That’s it!** Your 1Password connector is now pulling access data into ConductorOne
+**That’s it!** Your 1Password connector is now pulling access data into C1
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
Updates `docs/connector.mdx` with the C1 rebrand:

- Renames **ConductorOne** → **C1** in prose, comments, and placeholder text
- Updates brand color `#65DE23` → `#c937ae`
- Lowercases GitHub org name in the repository resource link

URLs that are case-sensitive or functional (distro site, tenant URLs, email addresses, file paths) are unchanged.