### PR TITLE
fix: mark credential fields secret

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,12 +32,14 @@ var (
 		"secret-key",
 		field.WithDescription("Secret-key of your 1password account"),
 		field.WithRequired(false),
+		field.WithIsSecret(true),
 	)
 
 	PasswordField = field.StringField(
 		"password",
 		field.WithDescription("Password of your 1password account"),
 		field.WithRequired(false),
+		field.WithIsSecret(true),
 	)
 
 	AddressField = field.StringField(


### PR DESCRIPTION
Marks the `secret-key` and `password` credential fields as secret so the values are obscured in the UI and kept out of plain-text storage.

**Breaking change:** existing plain-text configs will need the `secret-key` and `password` values re-entered after upgrade.

_(satellite) Built with stargate._