### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -38,15 +38,14 @@ func groupResource(group onepassword.Group, parentResourceID *v2.ResourceId) (*v
 		"group_id":   group.ID,
 	}
 
-	groupTraitOptions := []resource.GroupTraitOption{
-		resource.WithGroupProfile(profile),
-	}
+	groupTraitOptions := []resource.GroupTraitOption{}
 
 	ret, err := resource.NewGroupResource(
 		group.Name,
 		resourceTypeGroup,
 		group.ID,
 		groupTraitOptions,
+		resource.WithResourceProfile(profile),
 		resource.WithParentResourceID(parentResourceID),
 	)
 	if err != nil {

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -51,8 +51,6 @@ func userResource(user onepassword.User, parentResourceID *v2.ResourceId) (*v2.R
 	}
 
 	userTraitOptions := []resource.UserTraitOption{
-		resource.WithUserProfile(profile),
-		resource.WithStatus(userStatus),
 		resource.WithEmail(user.Email, true),
 	}
 
@@ -61,6 +59,8 @@ func userResource(user onepassword.User, parentResourceID *v2.ResourceId) (*v2.R
 		resourceTypeUser,
 		user.ID,
 		userTraitOptions,
+		resource.WithResourceProfile(profile),
+		resource.WithResourceStatus(v2.Status_ResourceStatus(userStatus), ""),
 		resource.WithParentResourceID(parentResourceID),
 	)
 	if err != nil {


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
